### PR TITLE
v2.1.15

### DIFF
--- a/Documentation/2.1/v2.1.15 Changes.md
+++ b/Documentation/2.1/v2.1.15 Changes.md
@@ -1,0 +1,35 @@
+Fixed class colors missing for imported players who haven't been seen in guild or raid.
+
+**Problem:** Players imported from Raid-Helper JSON or RaidRes showed white (uncolored) names in both the Invite Roster and Planning Roster panels. This happened because:
+
+1. Raid-Helper uses `className` for both actual WoW class AND signup status (`Tentative`, `Bench`, `Absence`, `Tank`, etc.). When className was a status/role, the parser set class to nil and fell back to `OGRH.GetPlayerClass()`, which can't resolve players never seen in guild/raid.
+2. RaidRes/RollFor softres data contains class info in the raw decoded JSON, but `GetSoftResPlayers` never extracted it — only name, role, and SR data were pulled from the transformer output.
+3. Even when class was known from import data, it was never written to `OGRH.classCache`, so other panels (RosterPanel, RolesUI) that call `GetPlayerClass()` couldn't find it.
+
+---
+
+### Spec-to-Class Inference (`Invites.lua`)
+
+Added `SPEC_TO_CLASS` lookup table mapping all 30 Raid-Helper spec names to WoW classes (e.g., `Feral → DRUID`, `Protection1 → PALADIN`, `Restoration1 → SHAMAN`). Added `CLASS_EMOTE_IDS` table as a last-resort fallback using Raid-Helper's class emoji IDs.
+
+New `InferClassFromSpec(signup)` function checks three sources in order:
+1. `specName` against `SPEC_TO_CLASS`
+2. `specName` as a raw class name (handles alt-signup edge cases like `specName: "Warrior"`)
+3. `classEmoteId` against `CLASS_EMOTE_IDS`
+
+Applied to all three parser paths:
+- **`ParseRaidHelperJSON`** — Tentative, Bench, Absence, and role-as-class signups now resolve class from spec
+- **`ParseRaidHelperGroupsJSON` (new format)** — Tank className and any future status classNames now use `InferClassFromSpec` instead of hardcoded Protection/Guardian checks
+- **`ParseRaidHelperGroupsJSON` (old raidDrop format)** — Added spec inference for benched players
+
+### Class Cache Population
+
+**`GetSoftResPlayers`** — Extracts class data from `decodedData.softreserves` (the raw raid-res JSON includes a `class` field per player entry that RollFor's `SoftResDataTransformer` discards when regrouping by item). Each player now gets `.class` set from this source.
+
+**`UpdatePlayerClass`** — Now seeds `OGRH.classCache` from `playerData.class` before doing guild/raid lookups, so import-sourced class data is available to all other panels.
+
+**`GeneratePlanningRoster`** — Also populates `OGRH.classCache` for each player with known class, covering the planning roster data path.
+
+---
+
+1 file modified: `_Configuration/Invites.lua`

--- a/OG-RaidHelper.toc
+++ b/OG-RaidHelper.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: OG-RaidHelper
 ## Author: Gnuzmas
-## Version: 2.1.14
+## Version: 2.1.15
 ## Notes: A comprehensive raid management addon for organizing encounters, assigning roles, managing trade distributions, coordinating raid activities, and validating soft-reserve integrity.
 ## SavedVariables: OGRH_SV, OGRH_ConsumeHelper_SV, OGAAL_SV
 ## OptionalDeps: _OGAddonMsg, _OGST, _OGAALogger 

--- a/_Core/Core.lua
+++ b/_Core/Core.lua
@@ -5,7 +5,7 @@ OGRH.CMD   = "ogrh"
 OGRH.ADDON_PREFIX = "OGRH"
 
 -- Code version: updated by bump.ps1, takes effect on /reload
-OGRH.CODE_VERSION = "2.1.14"
+OGRH.CODE_VERSION = "2.1.15"
 -- TOC version: only updates on full client restart
 OGRH.TOC_VERSION = GetAddOnMetadata("OG-RaidHelper", "Version") or "Unknown"
 -- Active version used for all version checks (code version = live reloadable)


### PR DESCRIPTION
Fixed class colors missing for imported players who haven't been seen in guild or raid.

**Problem:** Players imported from Raid-Helper JSON or RaidRes showed white (uncolored) names in both the Invite Roster and Planning Roster panels. This happened because:

1. Raid-Helper uses `className` for both actual WoW class AND signup status (`Tentative`, `Bench`, `Absence`, `Tank`, etc.). When className was a status/role, the parser set class to nil and fell back to `OGRH.GetPlayerClass()`, which can't resolve players never seen in guild/raid.
2. RaidRes/RollFor softres data contains class info in the raw decoded JSON, but `GetSoftResPlayers` never extracted it — only name, role, and SR data were pulled from the transformer output.
3. Even when class was known from import data, it was never written to `OGRH.classCache`, so other panels (RosterPanel, RolesUI) that call `GetPlayerClass()` couldn't find it.

---

### Spec-to-Class Inference (`Invites.lua`)

Added `SPEC_TO_CLASS` lookup table mapping all 30 Raid-Helper spec names to WoW classes (e.g., `Feral → DRUID`, `Protection1 → PALADIN`, `Restoration1 → SHAMAN`). Added `CLASS_EMOTE_IDS` table as a last-resort fallback using Raid-Helper's class emoji IDs.

New `InferClassFromSpec(signup)` function checks three sources in order:
1. `specName` against `SPEC_TO_CLASS`
2. `specName` as a raw class name (handles alt-signup edge cases like `specName: "Warrior"`)
3. `classEmoteId` against `CLASS_EMOTE_IDS`

Applied to all three parser paths:
- **`ParseRaidHelperJSON`** — Tentative, Bench, Absence, and role-as-class signups now resolve class from spec
- **`ParseRaidHelperGroupsJSON` (new format)** — Tank className and any future status classNames now use `InferClassFromSpec` instead of hardcoded Protection/Guardian checks
- **`ParseRaidHelperGroupsJSON` (old raidDrop format)** — Added spec inference for benched players

### Class Cache Population

**`GetSoftResPlayers`** — Extracts class data from `decodedData.softreserves` (the raw raid-res JSON includes a `class` field per player entry that RollFor's `SoftResDataTransformer` discards when regrouping by item). Each player now gets `.class` set from this source.

**`UpdatePlayerClass`** — Now seeds `OGRH.classCache` from `playerData.class` before doing guild/raid lookups, so import-sourced class data is available to all other panels.

**`GeneratePlanningRoster`** — Also populates `OGRH.classCache` for each player with known class, covering the planning roster data path.

---

1 file modified: `_Configuration/Invites.lua`
